### PR TITLE
Add email module

### DIFF
--- a/modules/email_module.py
+++ b/modules/email_module.py
@@ -1,0 +1,35 @@
+"""Simple email module for JARO-TOOTH.
+
+Provides basic communication hooks that can be imported by ``jaro_link_agent``.
+
+Functions
+---------
+start()
+    Print a confirmation that the email module started.
+send_email(ontvanger, onderwerp, bericht)
+    Simulate sending an email by printing the contents.
+
+This design keeps the module lightweight and easily extensible with real
+email-sending capabilities via SMTP or an API.
+"""
+
+
+def start():
+    """Initialize the email module."""
+    print("\U0001F4E7 Email module gestart")
+
+
+def send_email(ontvanger: str, onderwerp: str, bericht: str) -> None:
+    """Simulate sending an email.
+
+    Parameters
+    ----------
+    ontvanger : str
+        Recipient address.
+    onderwerp : str
+        Subject line.
+    bericht : str
+        Body of the email.
+    """
+    print(f"\u2709\ufe0f Simulatie: E-mail verzonden naar {ontvanger} met onderwerp: '{onderwerp}'")
+    print(f"Inhoud:\n{bericht}")


### PR DESCRIPTION
## Summary
- add a basic extensible `email_module` with simple start and send_email functions

## Testing
- `pytest -q` *(fails: fixture 'agent' not found)*
- `python tests/test_agent_run.py`

------
https://chatgpt.com/codex/tasks/task_e_68551f782b30832c88b613409da3f5a7