### PR TITLE
Add context switching feature

### DIFF
--- a/core/user_config.json
+++ b/core/user_config.json
@@ -21,6 +21,8 @@
     "niveau": "compact",
     "bestand": "activity_log.json"
   },
+  "context_mode": "werk",
+  "previous_context": "privé",
   "automatiseringsregels": [
     {
       "trigger": "08:00",

--- a/modules/braindump_module.py
+++ b/modules/braindump_module.py
@@ -1,0 +1,11 @@
+"""Braindump module voor JARO-TOOTH.
+
+Wordt geactiveerd in de context 'privé'. De functionaliteit is
+gesimuleerd via een simpel opstartbericht.
+"""
+
+
+def start() -> None:
+    """Initialiseer de braindump module."""
+    print("\U0001F4DD Braindump module gestart")
+

--- a/modules/highlight_module.py
+++ b/modules/highlight_module.py
@@ -1,0 +1,11 @@
+"""Highlight module voor JARO-TOOTH.
+
+Deze eenvoudige variant drukt enkel een bevestiging bij het starten
+en kan later uitgebreid worden met echte functionaliteit.
+"""
+
+
+def start() -> None:
+    """Start de highlight module."""
+    print("\U0001F3A5 Highlight module gestart")
+

--- a/modules/notities_module.py
+++ b/modules/notities_module.py
@@ -1,0 +1,11 @@
+"""Notities module voor JARO-TOOTH.
+
+Deze minimale implementatie wordt gebruikt om context switching te
+demonstreren. Bij het starten toont de module enkel een bericht.
+"""
+
+
+def start() -> None:
+    """Start de notities module."""
+    print("\U0001F4D1 Notities module gestart")
+

--- a/tests/simulate_context_switch.py
+++ b/tests/simulate_context_switch.py
@@ -1,0 +1,58 @@
+"""Simulatiescript voor het wisselen van contexten in JARO-TOOTH.
+
+Het script demonstreert de nieuwe CLI-commando's ``switch_context`` en
+``revert_context`` en toont welke modules per context worden gestart.
+"""
+
+from __future__ import annotations
+
+import os
+import subprocess
+import sys
+import json
+
+
+REPO_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+AGENT_PATH = os.path.join(REPO_DIR, "core", "jaro_link_agent.py")
+CONFIG_PATH = os.path.join(REPO_DIR, "core", "user_config.json")
+
+
+def _run_agent(args: list[str] | None = None) -> None:
+    cmd = [sys.executable, AGENT_PATH]
+    if args:
+        cmd.extend(args)
+    print("$", " ".join(cmd))
+    subprocess.run(cmd, check=False)
+
+
+def main() -> None:
+    with open(CONFIG_PATH, "r", encoding="utf-8") as f:
+        config = json.load(f)
+    orig_status = config.get("status", "UIT")
+    config["status"] = "AAN"
+    with open(CONFIG_PATH, "w", encoding="utf-8") as f:
+        json.dump(config, f, indent=2, ensure_ascii=False)
+
+    print("Start agent met standaardcontext:\n")
+    _run_agent([])
+
+    print("\nSchakel naar context 'privé':\n")
+    _run_agent(["switch_context", "privé"])
+
+    print("\nStart agent opnieuw:\n")
+    _run_agent([])
+
+    print("\nRollback naar vorige context:\n")
+    _run_agent(["revert_context"])
+
+    print("\nStart agent nogmaals:\n")
+    _run_agent([])
+
+    config["status"] = orig_status
+    with open(CONFIG_PATH, "w", encoding="utf-8") as f:
+        json.dump(config, f, indent=2, ensure_ascii=False)
+
+
+if __name__ == "__main__":
+    main()
+


### PR DESCRIPTION
## Summary
- add context fields to user_config
- implement context switching and rollback in `jaro_link_agent.py`
- load modules based on active context
- create simple modules for private context
- include simulation script to demo context changes

## Testing
- `pytest -q`
- `python tests/simulate_context_switch.py`

------
https://chatgpt.com/codex/tasks/task_e_68566b49df8c832ca2e957629aaa4447