### PR TITLE
Context simulation and run interface

### DIFF
--- a/core/jaro_link_agent.py
+++ b/core/jaro_link_agent.py
@@ -2,6 +2,7 @@ import json
 import importlib
 import os
 import sys
+import subprocess
 from datetime import datetime
 
 # Constants for status labels in Dutch
@@ -173,7 +174,13 @@ if __name__ == "__main__":
     agent = JaroLinkAgent()
     if len(sys.argv) >= 2:
         cmd = sys.argv[1]
-        if cmd == "switch_context" and len(sys.argv) >= 3:
+        if cmd == "--simulate":
+            sim_script = os.path.join(BASE_DIR, "..", "tests", "simulate_context_behavior.py")
+            try:
+                subprocess.run([sys.executable, sim_script], check=False)
+            except Exception as exc:
+                print(f"Kon simulatie niet uitvoeren: {exc}")
+        elif cmd == "switch_context" and len(sys.argv) >= 3:
             agent.switch_context(sys.argv[2])
         elif cmd == "revert_context":
             agent.revert_context()

--- a/modules/braindump_module.py
+++ b/modules/braindump_module.py
@@ -12,7 +12,8 @@ def start() -> None:
 
 def run(context: str = "werk") -> None:
     """Simuleer braindump functionaliteit afhankelijk van de context."""
-    print(f"[{context.upper()}] braindump_module gestart.")
+    label = "WERK" if context == "werk" else "PRIVÉ" if context == "privé" else "ONBEKEND"
+    print(f"[{label}] Braindump gestart")
 
     if context == "werk":
         print("\u25B6 Simuleer werkinhoud voor braindump_module...")

--- a/modules/calendar_module.py
+++ b/modules/calendar_module.py
@@ -26,7 +26,8 @@ def dagstart():
 
 def run(context: str = "werk") -> None:
     """Voer de kalenderfunctionaliteit contextbewust uit."""
-    print(f"[{context.upper()}] calendar_module gestart.")
+    label = "WERK" if context == "werk" else "PRIVÉ" if context == "privé" else "ONBEKEND"
+    print(f"[{label}] Calendar gestart")
 
     if context == "werk":
         print("\u25B6 Simuleer werkinhoud voor calendar_module...")

--- a/modules/email_module.py
+++ b/modules/email_module.py
@@ -37,7 +37,8 @@ def send_email(ontvanger: str, onderwerp: str, bericht: str) -> None:
 
 def run(context: str = "werk") -> None:
     """Simuleer contextbewuste e-mailafhandeling."""
-    print(f"[{context.upper()}] email_module gestart.")
+    label = "WERK" if context == "werk" else "PRIVÉ" if context == "privé" else "ONBEKEND"
+    print(f"[{label}] Email gestart")
 
     if context == "werk":
         print("\u25B6 Simuleer werkinhoud voor email_module...")

--- a/modules/files_module.py
+++ b/modules/files_module.py
@@ -112,7 +112,8 @@ def auto_sort(doelmap: str = "data") -> None:
 
 def run(context: str = "werk") -> None:
     """Simuleer bestandsbeheer voor beide contexten."""
-    print(f"[{context.upper()}] files_module gestart.")
+    label = "WERK" if context == "werk" else "PRIVÉ" if context == "privé" else "ONBEKEND"
+    print(f"[{label}] Bestanden gestart")
 
     if context in {"werk", "privé"}:
         print("\u25B6 Simuleer bestandsbeheer in files_module...")

--- a/modules/habit_tracker_module.py
+++ b/modules/habit_tracker_module.py
@@ -60,7 +60,8 @@ def log_habit(gewoonte: str, status: str, opmerking: str = "") -> Dict[str, str]
 
 def run(context: str = "werk") -> None:
     """Simuleer habit-tracker-acties afhankelijk van de context."""
-    print(f"[{context.upper()}] habit_tracker_module gestart.")
+    label = "WERK" if context == "werk" else "PRIVÉ" if context == "privé" else "ONBEKEND"
+    print(f"[{label}] Habit Tracker gestart")
 
     if context == "werk":
         print("\u25B6 Simuleer werkinhoud voor habit_tracker_module...")

--- a/modules/highlight_module.py
+++ b/modules/highlight_module.py
@@ -12,7 +12,8 @@ def start() -> None:
 
 def run(context: str = "werk") -> None:
     """Simuleer highlight-functionaliteit op basis van de context."""
-    print(f"[{context.upper()}] highlight_module gestart.")
+    label = "WERK" if context == "werk" else "PRIVÉ" if context == "privé" else "ONBEKEND"
+    print(f"[{label}] Highlight gestart")
 
     if context == "werk":
         print("\u25B6 Simuleer werkinhoud voor highlight_module...")

--- a/modules/notities_module.py
+++ b/modules/notities_module.py
@@ -12,7 +12,8 @@ def start() -> None:
 
 def run(context: str = "werk") -> None:
     """Toon gesimuleerde notities afhankelijk van de context."""
-    print(f"[{context.upper()}] notities_module gestart.")
+    label = "WERK" if context == "werk" else "PRIVÉ" if context == "privé" else "ONBEKEND"
+    print(f"[{label}] Notities gestart")
 
     if context == "werk":
         print("\u25B6 Simuleer werkinhoud voor notities_module...")

--- a/tests/simulate_context_behavior.py
+++ b/tests/simulate_context_behavior.py
@@ -1,0 +1,68 @@
+from __future__ import annotations
+
+import importlib
+import os
+import sys
+import logging
+from contextlib import redirect_stdout
+from io import StringIO
+
+REPO_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+MODULE_DIR = os.path.join(REPO_DIR, "modules")
+LOG_DIR = os.path.join(REPO_DIR, "logs")
+LOG_FILE = os.path.join(LOG_DIR, "context_simulation.log")
+
+os.makedirs(LOG_DIR, exist_ok=True)
+
+logging.basicConfig(
+    level=logging.INFO,
+    format="%(asctime)s %(message)s",
+    handlers=[
+        logging.FileHandler(LOG_FILE, encoding="utf-8"),
+        logging.StreamHandler(sys.stdout),
+    ],
+)
+
+
+def simulate() -> None:
+    """Doorloop alle modules en voer run(context) uit."""
+    modules = [m[:-3] for m in os.listdir(MODULE_DIR) if m.endswith("_module.py")]
+    sys.path.insert(0, MODULE_DIR)
+    contexts = ["werk", "privé"]
+
+    for mod_name in modules:
+        try:
+            module = importlib.import_module(mod_name)
+        except Exception as exc:
+            msg = f"Kon module {mod_name} niet laden: {exc}"
+            print(msg)
+            logging.error(msg)
+            continue
+
+        run_fn = getattr(module, "run", None)
+        for ctx in contexts:
+            header = f"----- {mod_name} ({ctx}) -----"
+            print(header)
+            logging.info(header)
+            if callable(run_fn):
+                buf = StringIO()
+                with redirect_stdout(buf):
+                    try:
+                        run_fn(context=ctx)
+                    except Exception as exc:
+                        print(f"Fout bij uitvoeren van {mod_name}: {exc}")
+                output = buf.getvalue()
+                buf.close()
+                print(output, end="")
+                for line in output.rstrip().splitlines():
+                    logging.info(line)
+            else:
+                warn = f"Waarschuwing: run() ontbreekt in {mod_name}"
+                print(warn)
+                logging.warning(warn)
+
+    logging.info("Simulatie afgerond")
+
+
+if __name__ == "__main__":
+    simulate()


### PR DESCRIPTION
## Summary
- add context-aware messaging in all modules
- provide context simulation script to loop modules
- extend `jaro_link_agent` with `--simulate` flag

## Testing
- `pytest -q`
- `python tests/simulate_context_behavior.py`

------
https://chatgpt.com/codex/tasks/task_e_685671780f3c832c870ad9dbe617b7aa