### PR TITLE
Enhance modules with config hooks

### DIFF
--- a/modules/braindump_module.py
+++ b/modules/braindump_module.py
@@ -4,14 +4,36 @@ Wordt geactiveerd in de context 'privé'. De functionaliteit is
 gesimuleerd via een simpel opstartbericht.
 """
 
+from core.jaro_manifest import get_manifest_value, is_allowed_to
+from core.user_config import get_user_value, is_user_enabled
+from datetime import datetime
+import os
+import logging
+
+__all__ = []
+
+logger = logging.getLogger(__name__)
+
+MANIFEST_DATA = get_manifest_value("contextual_info") or {}
+VISION = get_manifest_value("jaro_vision") or {}
+USER_PREFERENCES = get_user_value("personal_preferences") or {}
+USER_ACTIVE = is_user_enabled("pc_on") if not os.environ.get("JARO_OVERRIDE") else True
+
 
 def start() -> None:
     """Initialiseer de braindump module."""
+    logger.debug("Braindump module start() called")
     print("\U0001F4DD Braindump module gestart")
 
 
 def run(context: str = "werk") -> None:
     """Simuleer braindump functionaliteit afhankelijk van de context."""
+    if not USER_ACTIVE:
+        logger.debug("Gebruiker niet actief; braindump wordt niet uitgevoerd")
+        return
+
+    context = context or USER_PREFERENCES.get("active_context", "werk")
+    logger.debug("Braindump module run() with context: %s", context)
     label = "WERK" if context == "werk" else "PRIVÉ" if context == "privé" else "ONBEKEND"
     print(f"[{label}] Braindump gestart")
 

--- a/modules/calendar_module.py
+++ b/modules/calendar_module.py
@@ -13,19 +13,42 @@ This design keeps the module lightweight and allows future
 extension with reminders or agenda integrations.
 """
 
+from core.jaro_manifest import get_manifest_value, is_allowed_to
+from core.user_config import get_user_value, is_user_enabled
+from datetime import datetime
+import os
+import logging
+
+__all__ = []
+
+logger = logging.getLogger(__name__)
+
+MANIFEST_DATA = get_manifest_value("contextual_info") or {}
+VISION = get_manifest_value("jaro_vision") or {}
+USER_PREFERENCES = get_user_value("personal_preferences") or {}
+USER_ACTIVE = is_user_enabled("pc_on") if not os.environ.get("JARO_OVERRIDE") else True
+
 
 def start():
     """Initialize the calendar module."""
+    logger.debug("Calendar module start() called")
     print("\U0001F4C5 Calendar module succesvol gestart")
 
 
 def dagstart():
     """Trigger daily planning startup."""
+    logger.debug("Calendar dagstart() called")
     print("\U0001F31E Dagplanning geladen: klaar om te starten")
 
 
 def run(context: str = "werk") -> None:
     """Voer de kalenderfunctionaliteit contextbewust uit."""
+    if not USER_ACTIVE:
+        logger.debug("Gebruiker niet actief; calendar wordt niet uitgevoerd")
+        return
+
+    context = context or USER_PREFERENCES.get("active_context", "werk")
+    logger.debug("Calendar module run() with context: %s", context)
     label = "WERK" if context == "werk" else "PRIVÉ" if context == "privé" else "ONBEKEND"
     print(f"[{label}] Calendar gestart")
 

--- a/modules/email_module.py
+++ b/modules/email_module.py
@@ -13,9 +13,25 @@ This design keeps the module lightweight and easily extensible with real
 email-sending capabilities via SMTP or an API.
 """
 
+from core.jaro_manifest import get_manifest_value, is_allowed_to
+from core.user_config import get_user_value, is_user_enabled
+from datetime import datetime
+import os
+import logging
+
+__all__ = []
+
+logger = logging.getLogger(__name__)
+
+MANIFEST_DATA = get_manifest_value("contextual_info") or {}
+VISION = get_manifest_value("jaro_vision") or {}
+USER_PREFERENCES = get_user_value("personal_preferences") or {}
+USER_ACTIVE = is_user_enabled("pc_on") if not os.environ.get("JARO_OVERRIDE") else True
+
 
 def start():
     """Initialize the email module."""
+    logger.debug("Email module start() called")
     print("\U0001F4E7 Email module gestart")
 
 
@@ -31,12 +47,19 @@ def send_email(ontvanger: str, onderwerp: str, bericht: str) -> None:
     bericht : str
         Body of the email.
     """
+    logger.debug("send_email called to %s with subject %s", ontvanger, onderwerp)
     print(f"\u2709\ufe0f Simulatie: E-mail verzonden naar {ontvanger} met onderwerp: '{onderwerp}'")
     print(f"Inhoud:\n{bericht}")
 
 
 def run(context: str = "werk") -> None:
     """Simuleer contextbewuste e-mailafhandeling."""
+    if not USER_ACTIVE:
+        logger.debug("Gebruiker niet actief; email wordt niet uitgevoerd")
+        return
+
+    context = context or USER_PREFERENCES.get("active_context", "werk")
+    logger.debug("Email module run() with context: %s", context)
     label = "WERK" if context == "werk" else "PRIVÉ" if context == "privé" else "ONBEKEND"
     print(f"[{label}] Email gestart")
 

--- a/modules/habit_tracker_module.py
+++ b/modules/habit_tracker_module.py
@@ -15,12 +15,26 @@ habit-analyse, feedback op inconsistent gedrag en integratie met
 kalender- of reminderfunctionaliteit.
 """
 
+from core.jaro_manifest import get_manifest_value, is_allowed_to
+from core.user_config import get_user_value, is_user_enabled
 from datetime import datetime
+import os
+import logging
 from typing import Dict
+
+__all__ = []
+
+logger = logging.getLogger(__name__)
+
+MANIFEST_DATA = get_manifest_value("contextual_info") or {}
+VISION = get_manifest_value("jaro_vision") or {}
+USER_PREFERENCES = get_user_value("personal_preferences") or {}
+USER_ACTIVE = is_user_enabled("pc_on") if not os.environ.get("JARO_OVERRIDE") else True
 
 
 def start() -> None:
     """Initialiseer de habit tracker module."""
+    logger.debug("Habit tracker module start() called")
     print("\U0001F4DD Habit tracker module gestart")
 
 
@@ -50,6 +64,7 @@ def log_habit(gewoonte: str, status: str, opmerking: str = "") -> Dict[str, str]
         "opmerking": opmerking,
     }
 
+    logger.debug("Log habit %s status %s", gewoonte, status)
     print(f"{icon} Gewoonte '{gewoonte}' gemarkeerd als {status}")
     if opmerking:
         print(f"\U0001F4DD Opmerking: {opmerking}")
@@ -60,6 +75,12 @@ def log_habit(gewoonte: str, status: str, opmerking: str = "") -> Dict[str, str]
 
 def run(context: str = "werk") -> None:
     """Simuleer habit-tracker-acties afhankelijk van de context."""
+    if not USER_ACTIVE:
+        logger.debug("Gebruiker niet actief; habit tracker wordt niet uitgevoerd")
+        return
+
+    context = context or USER_PREFERENCES.get("active_context", "werk")
+    logger.debug("Habit tracker run() with context: %s", context)
     label = "WERK" if context == "werk" else "PRIVÉ" if context == "privé" else "ONBEKEND"
     print(f"[{label}] Habit Tracker gestart")
 

--- a/modules/highlight_module.py
+++ b/modules/highlight_module.py
@@ -4,14 +4,36 @@ Deze eenvoudige variant drukt enkel een bevestiging bij het starten
 en kan later uitgebreid worden met echte functionaliteit.
 """
 
+from core.jaro_manifest import get_manifest_value, is_allowed_to
+from core.user_config import get_user_value, is_user_enabled
+from datetime import datetime
+import os
+import logging
+
+__all__ = []
+
+logger = logging.getLogger(__name__)
+
+MANIFEST_DATA = get_manifest_value("contextual_info") or {}
+VISION = get_manifest_value("jaro_vision") or {}
+USER_PREFERENCES = get_user_value("personal_preferences") or {}
+USER_ACTIVE = is_user_enabled("pc_on") if not os.environ.get("JARO_OVERRIDE") else True
+
 
 def start() -> None:
     """Start de highlight module."""
+    logger.debug("Highlight module start() called")
     print("\U0001F3A5 Highlight module gestart")
 
 
 def run(context: str = "werk") -> None:
     """Simuleer highlight-functionaliteit op basis van de context."""
+    if not USER_ACTIVE:
+        logger.debug("Gebruiker niet actief; highlight wordt niet uitgevoerd")
+        return
+
+    context = context or USER_PREFERENCES.get("active_context", "werk")
+    logger.debug("Highlight module run() with context: %s", context)
     label = "WERK" if context == "werk" else "PRIVÉ" if context == "privé" else "ONBEKEND"
     print(f"[{label}] Highlight gestart")
 

--- a/modules/notities_module.py
+++ b/modules/notities_module.py
@@ -4,14 +4,36 @@ Deze minimale implementatie wordt gebruikt om context switching te
 demonstreren. Bij het starten toont de module enkel een bericht.
 """
 
+from core.jaro_manifest import get_manifest_value, is_allowed_to
+from core.user_config import get_user_value, is_user_enabled
+from datetime import datetime
+import os
+import logging
+
+__all__ = []
+
+logger = logging.getLogger(__name__)
+
+MANIFEST_DATA = get_manifest_value("contextual_info") or {}
+VISION = get_manifest_value("jaro_vision") or {}
+USER_PREFERENCES = get_user_value("personal_preferences") or {}
+USER_ACTIVE = is_user_enabled("pc_on") if not os.environ.get("JARO_OVERRIDE") else True
+
 
 def start() -> None:
     """Start de notities module."""
+    logger.debug("Notities module start() called")
     print("\U0001F4D1 Notities module gestart")
 
 
 def run(context: str = "werk") -> None:
     """Toon gesimuleerde notities afhankelijk van de context."""
+    if not USER_ACTIVE:
+        logger.debug("Gebruiker niet actief; notities wordt niet uitgevoerd")
+        return
+
+    context = context or USER_PREFERENCES.get("active_context", "werk")
+    logger.debug("Notities module run() met context: %s", context)
     label = "WERK" if context == "werk" else "PRIVÉ" if context == "privé" else "ONBEKEND"
     print(f"[{label}] Notities gestart")
 


### PR DESCRIPTION
## Summary
- add manifest and user config integration imports to each module
- expose `MANIFEST_DATA`, `VISION`, `USER_PREFERENCES`, and `USER_ACTIVE`
- initialize a logger per module for easier debugging
- respect user preferences in each module `run()` function

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685ba59db1f8832c90a1e8713d606c99