### PR TITLE
Implement live reload for config and manifest

### DIFF
--- a/core/jaro_manifest.py
+++ b/core/jaro_manifest.py
@@ -109,3 +109,9 @@ def save_manifest(data: dict) -> None:
         json.dump(data, f, indent=2, ensure_ascii=False)
     MANIFEST_DATA = data
     _log("ok", "Manifest bijgewerkt")
+
+
+def reload_manifest() -> None:
+    """Herlaad het manifest van schijf."""
+    global MANIFEST_DATA
+    MANIFEST_DATA = load_manifest()

--- a/core/user_config.py
+++ b/core/user_config.py
@@ -93,11 +93,10 @@ def is_user_enabled(key: str) -> bool:
     return _search_key(USER_CONFIG_DATA, key)
 
 
-def reload_user_config() -> dict:
-    """Herlaad de configuratie van schijf en ververs de globale versie."""
+def reload_user_config() -> None:
+    """Herlaad de configuratie van schijf."""
     global USER_CONFIG_DATA
-    USER_CONFIG_DATA = None
-    return load_user_config()
+    USER_CONFIG_DATA = load_user_config()
 
 
 def profile_info() -> None:


### PR DESCRIPTION
## Summary
- add a simple `reload_manifest` to refresh manifest data from disk
- simplify `reload_user_config` to reload and store config

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685baca407e4832ca946011a7c0d6129